### PR TITLE
feat: Allow concurrent jenkins builds

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -270,7 +270,7 @@ func (j *Jenkins) BuildJob(name string, options ...interface{}) (int64, error) {
 	if len(options) > 0 {
 		params, _ = options[0].(map[string]string)
 	}
-	return job.InvokeSimple(params)
+	return job.InvokeSimple(params, false)
 }
 
 func (j *Jenkins) GetNode(name string) (*Node, error) {

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -37,7 +37,6 @@ func TestCreateJobs(t *testing.T) {
 	assert.Equal(t, job2ID, job2.GetName())
 }
 
-
 func TestCreateNodes(t *testing.T) {
 
 	id1 := "node1_test"
@@ -69,7 +68,7 @@ func TestDeleteNodes(t *testing.T) {
 func TestCreateBuilds(t *testing.T) {
 	jobs, _ := jenkins.GetAllJobs()
 	for _, item := range jobs {
-		queueID, _ = item.InvokeSimple(map[string]string{"params1": "param1"})
+		queueID, _ = item.InvokeSimple(map[string]string{"params1": "param1"}, false)
 		item.Poll()
 		isQueued, _ := item.IsQueued()
 		assert.Equal(t, true, isQueued)

--- a/job.go
+++ b/job.go
@@ -418,14 +418,16 @@ func (j *Job) HasQueuedBuild() {
 	panic("Not Implemented yet")
 }
 
-func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
-	isQueued, err := j.IsQueued()
-	if err != nil {
-		return 0, err
-	}
-	if isQueued {
-		Error.Printf("%s is already running", j.GetName())
-		return 0, nil
+func (j *Job) InvokeSimple(params map[string]string, skipIfRunning bool) (int64, error) {
+	if skipIfRunning {
+		isQueued, err := j.IsQueued()
+		if err != nil {
+			return 0, err
+		}
+		if isQueued {
+			Error.Printf("%s is already running", j.GetName())
+			return 0, nil
+		}
 	}
 
 	endpoint := "/build"


### PR DESCRIPTION
This adds the ability to run concurrent builds. This is done by
preventing a check on the entire job which prevents more than one being
queued.